### PR TITLE
Past consultations appear on the bottom of consultation landing.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decidim-consultations (0.1.16)
+    decidim-consultations (0.1.17)
       decidim-admin (~> 0.8.3)
       decidim-comments (~> 0.8.3)
       decidim-core (~> 0.8.3)

--- a/app/controllers/decidim/consultations/consultations_controller.rb
+++ b/app/controllers/decidim/consultations/consultations_controller.rb
@@ -12,7 +12,7 @@ module Decidim
       include Paginable
       include Orderable
 
-      helper_method :collection, :consultations, :filter
+      helper_method :collection, :consultations, :finished_consultations, :filter
 
       helper Decidim::FiltersHelper
       helper Decidim::OrdersHelper
@@ -22,10 +22,7 @@ module Decidim
 
       def index
         authorize! :read, Consultation
-
-        if OrganizationConsultations.for(current_organization).published.count == 1
-          redirect_to consultation_path(OrganizationConsultations.for(current_organization).published.first)
-        end
+        redirect_to consultation_path(active_consultations.first) if active_consultations.count == 1
       end
 
       def show
@@ -33,6 +30,14 @@ module Decidim
       end
 
       private
+
+      def finished_consultations
+        @past_cosultations ||= OrganizationConsultations.for(current_organization).finished.published
+      end
+
+      def active_consultations
+        @active_consultations ||= OrganizationConsultations.for(current_organization).active.published
+      end
 
       def consultations
         @consultations = search.results

--- a/app/views/decidim/consultations/consultations/_finished_consultations.html.erb
+++ b/app/views/decidim/consultations/consultations/_finished_consultations.html.erb
@@ -1,0 +1,15 @@
+<% if finished_consultations.any? %>
+  <section id="finished-consultations" class="row section">
+    <h4 class=section-heading>
+      <%= t "consultations.finished_consultations.title", scope: "decidim" %>
+    </h4>
+
+    <div class="row">
+      <div class="columns mediumlarge-12 large-12">
+        <div class="row small-up-1 medium-up-2 card-grid">
+          <%= render finished_consultations %>
+        </div>
+      </div>
+    </div>
+  </section>
+<% end %>

--- a/app/views/decidim/consultations/consultations/show.html.erb
+++ b/app/views/decidim/consultations/consultations/show.html.erb
@@ -18,3 +18,4 @@
 
 <%= render partial: "highlighted_questions", locals: { consultation: current_consultation } %>
 <%= render partial: "regular_questions", locals: { consultation: current_consultation } %>
+<%= render partial: "finished_consultations" %>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -165,6 +165,8 @@ ca:
           recent: Més recent
       highlighted_questions:
         title: Consultes de %{scope_name}
+      finished_consultations:
+        title: Multiconsultes anteriors
       regular_questions:
         title: Altres consultes
       highlighted_question:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,6 +165,8 @@ en:
           recent: Most recent
       highlighted_questions:
         title: Consultations from %{scope_name}
+      finished_consultations:
+        title: Past consultations
       regular_questions:
         title: Other consultations
       highlighted_question:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -165,6 +165,8 @@ es:
           recent: Mas reciente
       highlighted_questions:
         title: Consultas de %{scope_name}
+      finished_consultations:
+        title: Multiconsultas anteriores
       regular_questions:
         title: Otras consultas
       highlighted_question:

--- a/lib/decidim/consultations/version.rb
+++ b/lib/decidim/consultations/version.rb
@@ -2,6 +2,6 @@
 
 module Decidim
   module Consultations
-    VERSION = "0.1.16"
+    VERSION = "0.1.17"
   end
 end

--- a/spec/features/consultation_spec.rb
+++ b/spec/features/consultation_spec.rb
@@ -72,4 +72,18 @@ describe "Consultation", type: :feature do
       expect(page).to have_i18n_content(question.subtitle)
     end
   end
+
+  context "when finished consultations" do
+    let!(:finished_consultation) { create :consultation, :finished, :published, organization: organization }
+
+    before do
+      switch_to_host(organization.host)
+      visit decidim_consultations.consultation_path(consultation)
+    end
+
+    it "consultation page contains finished consultations" do
+      expect(page).to have_content("PAST CONSULTATIONS")
+      expect(page).to have_i18n_content(finished_consultation.title)
+    end
+  end
 end

--- a/spec/features/consultations_spec.rb
+++ b/spec/features/consultations_spec.rb
@@ -50,8 +50,9 @@ describe "Consultations", type: :feature do
     end
   end
 
-  context "when there is only one consultation in the organization" do
-    let!(:consultation) { create(:consultation, :published, organization: organization) }
+  context "when there is only one active consultation in the organization" do
+    let!(:consultation) { create(:consultation, :active, :published, organization: organization) }
+    let!(:finished_consultation) { create :consultation, :finished, :published, organization: organization }
 
     before do
       switch_to_host(organization.host)


### PR DESCRIPTION
#### :tophat: What? Why?

* Past consultations appear on the bottom of consultation landing. 
* When there is only one active consultation the user will be automatically redirected to this consultation.

#### :pushpin: Related Issues
- Related to #38 