### PR TITLE
Question sorting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decidim-consultations (0.3.13)
+    decidim-consultations (0.3.14)
       decidim-admin (~> 0.9.0)
       decidim-comments (~> 0.9.0)
       decidim-core (~> 0.9.0)

--- a/app/commands/decidim/consultations/admin/create_question.rb
+++ b/app/commands/decidim/consultations/admin/create_question.rb
@@ -54,7 +54,8 @@ module Decidim
             origin_title: form.origin_title,
             origin_url: form.origin_url,
             external_voting: form.external_voting,
-            i_frame_url: form.i_frame_url
+            i_frame_url: form.i_frame_url,
+            order: form.order
           )
 
           return question unless question.valid?

--- a/app/commands/decidim/consultations/admin/update_question.rb
+++ b/app/commands/decidim/consultations/admin/update_question.rb
@@ -62,7 +62,8 @@ module Decidim
             origin_title: form.origin_title,
             origin_url: form.origin_url,
             external_voting: form.external_voting,
-            i_frame_url: form.i_frame_url
+            i_frame_url: form.i_frame_url,
+            order: form.order
           }
         end
       end

--- a/app/forms/decidim/consultations/admin/question_form.rb
+++ b/app/forms/decidim/consultations/admin/question_form.rb
@@ -27,6 +27,7 @@ module Decidim
         attribute :decidim_scope_id, Integer
         attribute :external_voting, Boolean, default: false
         attribute :i_frame_url, String
+        attribute :order, Integer
 
         validates :slug, presence: true, format: { with: Decidim::Consultations::Question.slug_format }
         validates :title, :promoter_group, :participatory_scope, :subtitle, :what_is_decided, translatable_presence: true
@@ -36,6 +37,7 @@ module Decidim
         validate :slug_uniqueness
         validates :origin_scope, :origin_title, translatable_presence: true, if: :has_origin_data?
         validates :i_frame_url, presence: true, if: :external_voting
+        validates :order, numericality: { only_integer: true, allow_nil: true, allow_blank: true }
 
         private
 

--- a/app/models/decidim/consultations/question.rb
+++ b/app/models/decidim/consultations/question.rb
@@ -42,7 +42,7 @@ module Decidim
       mount_uploader :hero_image, Decidim::HeroImageUploader
       mount_uploader :banner_image, Decidim::BannerImageUploader
 
-      scope :order_by_most_recent, -> { order(created_at: :desc) }
+      default_scope { order(order: :asc) }
 
       delegate :start_voting_date, to: :consultation
       delegate :end_voting_date, to: :consultation

--- a/app/views/decidim/consultations/admin/questions/_form.html.erb
+++ b/app/views/decidim/consultations/admin/questions/_form.html.erb
@@ -31,7 +31,7 @@
     </div>
 
     <div class="row column">
-      <%= scopes_picker_field form, :decidim_scope_id %>
+      <%= scopes_picker_field form, :decidim_scope_id, root: nil %>
     </div>
 
     <div class="row column">
@@ -46,7 +46,11 @@
       <%= form.url_field :origin_url %>
     </div>
 
-    <div class="fow column">
+    <div class="row column">
+      <%= form.number_field :order, step: 1, min: 0 %>
+    </div>
+
+    <div class="row column">
       <%= form.text_field :slug %>
       <p class="help-text">
         <%== t "consultations.form.slug_help",
@@ -69,7 +73,7 @@
       </div>
 
       <div class="columns xlarge-4">
-        <%= form.upload :hero_image %>        
+        <%= form.upload :hero_image %>
       </div>
 
       <div class="columns xlarge-4">

--- a/db/migrate/20180219092120_add_order_to_decidim_consultations_questions.rb
+++ b/db/migrate/20180219092120_add_order_to_decidim_consultations_questions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrderToDecidimConsultationsQuestions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decidim_consultations_questions, :order, :integer, index: true
+  end
+end

--- a/lib/decidim/consultations/test/factories.rb
+++ b/lib/decidim/consultations/test/factories.rb
@@ -73,6 +73,9 @@ FactoryBot.define do
     hero_image { Decidim::Dev.test_file("city.jpeg", "image/jpeg") }
     banner_image { Decidim::Dev.test_file("city2.jpeg", "image/jpeg") }
     external_voting false
+    sequence :order do |n|
+      n
+    end
 
     trait :unpublished do
       published_at nil

--- a/lib/decidim/consultations/version.rb
+++ b/lib/decidim/consultations/version.rb
@@ -2,6 +2,6 @@
 
 module Decidim
   module Consultations
-    VERSION = "0.3.13"
+    VERSION = "0.3.14"
   end
 end

--- a/spec/commands/decidim/consultations/admin/create_question_spec.rb
+++ b/spec/commands/decidim/consultations/admin/create_question_spec.rb
@@ -26,7 +26,8 @@ module Decidim
               decidim_scope_id: scope.id,
               banner_image: banner_image,
               hero_image: hero_image,
-              external_voting: false
+              external_voting: false,
+              order: 1
             }
           }
         end

--- a/spec/commands/decidim/consultations/admin/update_question_spec.rb
+++ b/spec/commands/decidim/consultations/admin/update_question_spec.rb
@@ -33,7 +33,8 @@ module Decidim
               banner_image: question.banner_image,
               hero_image: question.hero_image,
               hashtag: question.hashtag,
-              decidim_scope_id: question.scope.id
+              decidim_scope_id: question.scope.id,
+              order: question.order
             }
           }
         end

--- a/spec/forms/decidim/consultations/admin/question_form_spec.rb
+++ b/spec/forms/decidim/consultations/admin/question_form_spec.rb
@@ -73,6 +73,7 @@ module Decidim
         let(:origin_url) { nil }
         let(:external_voting) { false }
         let(:i_frame_url) { nil }
+        let(:order) { 1 }
         let(:attributes) do
           {
             "question" => {
@@ -103,7 +104,8 @@ module Decidim
               "origin_title_ca" => origin_title[:ca],
               "origin_url" => origin_url,
               "external_voting" => external_voting,
-              "i_frame_url" => i_frame_url
+              "i_frame_url" => i_frame_url,
+              "order": order
             }
           }
         end
@@ -126,7 +128,7 @@ module Decidim
             it { is_expected.not_to be_valid }
           end
 
-          context "it hasn't the expected type" do
+          context "and it hasn't the expected type" do
             let(:banner_image) { Decidim::Dev.test_file("Exampledocument.pdf", "application/pdf") }
 
             it { is_expected.not_to be_valid }
@@ -143,7 +145,7 @@ module Decidim
             it { is_expected.not_to be_valid }
           end
 
-          context "it hasn't the expected type" do
+          context "and it hasn't the expected type" do
             let(:hero_image) { Decidim::Dev.test_file("Exampledocument.pdf", "application/pdf") }
 
             it { is_expected.not_to be_valid }
@@ -269,6 +271,12 @@ module Decidim
 
             it { is_expected.to be_invalid }
           end
+        end
+
+        context "when order is nil" do
+          let(:order) { nil }
+
+          it { is_expected.to be_valid }
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

Adds order field for questions allowing the administrator to define the
order for the questions in the consultation landing page.

#### :pushpin: Related Issues
- Related to #75 
